### PR TITLE
Modified Crafting and Inv screen.

### DIFF
--- a/packs/RP/ui/inventory_screen.json
+++ b/packs/RP/ui/inventory_screen.json
@@ -1,0 +1,47 @@
+{
+  // ## Remove toolbar.
+  "toolbar_panel": {
+    "ignored": true
+  },
+  // ## Remove recipe toggle
+  "recipe_inventory_screen_content/content_stack_panel/recipe_book": {
+    "ignored": true
+  },
+  // ## Remove that center background.
+  "recipe_inventory_screen_content/content_stack_panel/center_fold": {
+    "ignored": true
+  },
+  // ## Remove Shield slot.
+  // WARN: Controller's "Y" button or Ctrl + L-click may still
+  // insert the stuff into shield slot.
+  // there's probably a fix for it but not now lol.
+  "player_armor_panel/offhand_grid": {
+    "ignored": true
+  },
+  // ## Adds some padding because apparently they're not dynamically centered.
+  //    Thanks mojang, very cool!
+  "recipe_inventory_screen_content/content_stack_panel": {
+    "modifications": [
+      { "array_name": "controls",
+        "operation": "insert_front",
+        "value": [
+          { "recipe_book@crafting.recipe_book": {
+              "size": [ "fill", "100%" ],
+              "bindings": [
+                { "binding_type": "global",
+                  "binding_name": "(#is_creative_layout)",
+                  "binding_name_override": "#visible"
+              }]
+          }},
+          { "survival_padding_no_recipe": {
+              "type": "panel",
+              "size": [ 75, "100%" ],
+              "bindings": [
+                { "binding_type": "global",
+                  "binding_name": "(not #is_survival_layout)",
+                  "binding_name_override": "#visible"
+              }]
+          }}
+      ]}
+  ]}
+}

--- a/packs/RP/ui/inventory_screen_pocket.json
+++ b/packs/RP/ui/inventory_screen_pocket.json
@@ -1,0 +1,29 @@
+{
+  // ## Remove Recipe content for performance since it's no use.
+  "left_panel/recipe_book_tab_content": {
+    "ignored": true
+  },
+  // ## Remove all recipe tabs.
+  "left_tab_navigation_panel_pocket/content/search_tab_panel": {
+    "ignored": true
+  },
+  "left_tab_navigation_panel_pocket/content/construction_tab_panel": {
+    "ignored": true
+  },
+  "left_tab_navigation_panel_pocket/content/equipment_tab_panel": {
+    "ignored": true
+  },
+  "left_tab_navigation_panel_pocket/content/items_tab_panel": {
+    "ignored": true
+  },
+  "left_tab_navigation_panel_pocket/content/nature_tab_panel": {
+    "ignored": true
+  },
+  // ## Remove Shield slot.
+  // WARN: Controller's "Y" button or Ctrl + L-click may still
+  // insert the stuff into shield slot.
+  // there's probably a fix for it but not now lol.
+  "pocket_armor_tab_content/equipment_and_renderer/equipment/offhand_grid": {
+    "ignored": true
+  }
+}


### PR DESCRIPTION
- Removed Shield/Offhand slot. (All)
   - Known issues: Fast item insert shortcut like "Y" button (Controller), Double tapping (Touch) and Ctrl-M0 (K&M) will work as usual. there's probably a way to disable those control mappings but probably later for now.
- Removed Recipe book related elements (All)
   - Known Issue: Creative mode only works on Classic UI atm.
- Removed Toolbar element (Classic UI)
- Removed nearly all tabs except inventory button (Pocket UI)
