### PR TITLE
UI Update - Playerlist with Tab, Improved Pause Screen, etc.

### DIFF
--- a/packs/RP/textures/ui/vanilla_default.json
+++ b/packs/RP/textures/ui/vanilla_default.json
@@ -1,0 +1,4 @@
+{
+  "nineslice_size": 3,
+  "base_size": [ 200, 20 ]
+}

--- a/packs/RP/textures/ui/vanilla_locked.json
+++ b/packs/RP/textures/ui/vanilla_locked.json
@@ -1,0 +1,4 @@
+{
+  "nineslice_size": 3,
+  "base_size": [ 200, 20 ]
+}

--- a/packs/RP/textures/ui/vanilla_pressed.json
+++ b/packs/RP/textures/ui/vanilla_pressed.json
@@ -1,0 +1,4 @@
+{
+  "nineslice_size": 3,
+  "base_size": [ 200, 20 ]
+}

--- a/packs/RP/ui/chat_screen.json
+++ b/packs/RP/ui/chat_screen.json
@@ -1,6 +1,6 @@
 {
     "chat_screen": {
-        "$screen_content": "chat.main_screen",
+        "$screen_content": "chat.root_panels",
         "$screen_bg_content": "common.empty_panel",
         "button_mappings": [
             {
@@ -44,52 +44,14 @@
             }
         ]
     },
-    "close_button_default": {
-        "type": "label",
-        "text": "X"
-    },
-    "close_button_pressed": {
-        "type": "label",
-        "text": "§eX"
-    },
-    "close_button@common.button": {
-        "$pressed_button_name": "button.menu_exit",
-        "size": [
-            27,
-            27
-        ],
-        "focus_enabled": false,
+    "root_panels": {
+        "type": "panel",
         "controls": [
             {
-                "default@close_button_default": {}
+                "close_button_element@crafting.close_button_element": {}
             },
             {
-                "hover@close_button_pressed": {}
-            },
-            {
-                "pressed@close_button_pressed": {}
-            }
-        ]
-    },
-    "close_button_element": {
-        "type": "image",
-        "texture": "textures/ui/hud_tip_text_background",
-        "size": [
-            27,
-            27
-        ],
-        "anchor_from": "top_right",
-        "anchor_to": "top_right",
-        "offset": [
-            -8,
-            0
-        ],
-        "alpha": 0.7,
-        "controls": [
-            {
-                "close_button@close_button": {
-                    "layer": 2
-                }
+                "main_screen@chat.main_screen": {}
             }
         ]
     },
@@ -103,31 +65,6 @@
             "100%"
         ],
         "controls": [
-            {
-                "prefiller": {
-                    "type": "panel",
-                    "size": [
-                        1,
-                        8
-                    ]
-                }
-            },
-            {
-                "panel": {
-                    "type": "panel",
-                    "size": [
-                        "100%",
-                        27
-                    ],
-                    "anchor_from": "top_right",
-                    "anchor_to": "top_right",
-                    "controls": [
-                        {
-                            "close_button_element@chat.close_button_element": {}
-                        }
-                    ]
-                }
-            },
             {
                 "filler": {
                     "type": "panel",
@@ -145,7 +82,7 @@
                     "type": "panel",
                     "size": [
                         1,
-                        26
+                        29
                     ]
                 }
             },
@@ -204,8 +141,11 @@
                         {
                             "chat_textbox@chat.chat_textbox": {}
                         },
+                        // FIX: This thing screams orientation errors for some weird reason.
+                        //      Maybe this might be that the parent element is a stack and this button element
+                        //      attempt to be an stack panel.
                         {
-                            "chat_send_btn@common_buttons.light_text_form_fitting_button": {
+                            "chat_send_btn@common_buttons.light_text_button": {
                                 "$pressed_button_name": "button.send",
                                 "$anchor": "bottom_right",
                                 "size": [
@@ -283,15 +223,15 @@
                     ],
                     "$scrolling_pane_offset": [
                         0,
-                        0
+                        -1
                     ],
                     "$scroll_track_offset": [
                         0,
                         0
                     ],
                     "$scroll_track_image_control": "common.empty_panel",
-                    "$scroll_box_mouse_image_control": "$scroll_box_image_control",
-                    "$scroll_box_touch_image_control": "$scroll_box_image_control",
+                    "$scroll_box_mouse_image_control": "common.empty_panel",
+                    "$scroll_box_touch_image_control": "common.empty_panel",
                     "$jump_to_bottom_on_update": true,
                     "$always_handle_scrolling": true,
                     "$scrolling_content": "chat.messages_stack_panel"
@@ -425,7 +365,7 @@
     "chat_grid_item": {
         "type": "image",
         "size": [
-            324,
+            312,
             "100%c"
         ],
         "texture": "textures/chyves/color_base",
@@ -583,9 +523,6 @@
                     "controls": [
                         {
                             "texture@chat.text_field_highlighted_image": {}
-                        },
-                        {
-                            "hover_content@$hover_content": {}
                         }
                     ]
                 }
@@ -597,21 +534,6 @@
                     "controls": [
                         {
                             "texture@chat.text_field_highlighted_image": {}
-                        }
-                    ]
-                }
-            },
-            {
-                "locked": {
-                    "type": "panel",
-                    "layer": 3,
-                    "$disabled_color|default": "$color",
-                    "controls": [
-                        {
-                            "texture@chat.text_field_image": {
-                                "color": "$disabled_color",
-                                "alpha": 1.0
-                            }
                         }
                     ]
                 }

--- a/packs/RP/ui/hud_screen.json
+++ b/packs/RP/ui/hud_screen.json
@@ -23,344 +23,184 @@
     "hunger_renderer": {
         "ignored": true
     },
-    
 	"cursor_renderer": {
 		"ignored": true
 	},
     "crosshair_pixel": {
 		"type": "custom",
 		"renderer": "gradient_renderer",
-		"color1": [
-			1,
-			1,
-			1,
-			1
-		],
-		"color2": [
-			1,
-			1,
-			1,
-			1
-		],
-		"size": [
-			1,
-			1
-		]
+		"color1": [ 1, 1, 1, 1 ],
+		"color2": [ 1, 1, 1, 1 ],
+		"size": [ 1, 1 ]
 	},
-	"crosshair": {
-		"type": "panel",
-		"size": [
-			16,
-			16
-		],
-		"anchor_from": "center",
-		"anchor_to": "center",
-		"controls": [
-			{
-				"center@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						0
-					]
-				}
-			},
-			{
-				"v5@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						-4
-					]
-				}
-			},
-			{
-				"v6@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						-3
-					]
-				}
-			},
-			{
-				"v7@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						-2
-					]
-				}
-			},
-			{
-				"v8@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						-1
-					]
-				}
-			},
-			{
-				"v9@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						1
-					]
-				}
-			},
-			{
-				"v10@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						2
-					]
-				}
-			},
-			{
-				"v11@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						3
-					]
-				}
-			},
-			{
-				"v12@hud.crosshair_pixel": {
-					"offset": [
-						0,
-						4
-					]
-				}
-			},
-			{
-				"h5@hud.crosshair_pixel": {
-					"offset": [
-						-4,
-						0
-					]
-				}
-			},
-			{
-				"h6@hud.crosshair_pixel": {
-					"offset": [
-						-3,
-						0
-					]
-				}
-			},
-			{
-				"h7@hud.crosshair_pixel": {
-					"offset": [
-						-2,
-						0
-					]
-				}
-			},
-			{
-				"h8@hud.crosshair_pixel": {
-					"offset": [
-						-1,
-						0
-					]
-				}
-			},
-			{
-				"h9@hud.crosshair_pixel": {
-					"offset": [
-						1,
-						0
-					]
-				}
-			},
-			{
-				"h10@hud.crosshair_pixel": {
-					"offset": [
-						2,
-						0
-					]
-				}
-			},
-			{
-				"h11@hud.crosshair_pixel": {
-					"offset": [
-						3,
-						0
-					]
-				}
-			},
-			{
-				"h12@hud.crosshair_pixel": {
-					"offset": [
-						4,
-						0
-					]
-				}
-			}
-		]
-	},
-  // ## Import chat panel bottom element.
-  "root_panel": {
-    "modifications": [
-      { "array_name": "controls",
-        "operation": "insert_front",
-        "value": [
-          { "chat_panel_chyves@hud.chat_panel_chyves": {}},
-            {
-						"crosshair_chyves@hud.crosshair": {}
-					}
-      ]}
-  ]},
-  
-	"chat_panel": {
-        "ignored": true,
-        "size": [
-            0,
-            0
-        ]
-    },
-	"chat_panel_chyves": {
-        "type": "stack_panel",
-        "size": [
-            324,
-            "100%"
-        ],
-        "offset": [
-            2,
-            0
-        ],
-        "orientation": "vertical",
-        "anchor_from": "bottom_left",
-        "anchor_to": "bottom_left",
-        "controls": [
-            {
-                "filler": {
-                    "type": "panel",
-                    "size": [
-                        1,
-                        "fill"
-                    ]
-                }
-            },
-            {
-                "chat_stack_panel@hud.chat_stack_panel": {}
-            },
-            {
-                "buffer": {
-                    "type": "panel",
-                    "size": [
-                        0,
-                        39
-                    ]
-                }
-            }
-        ]
-    },
-    "chat_stack_panel": {
+    "crosshair": {
         "type": "panel",
-        "layer": 150,
-        "size": [
-            "100%",
-            "100%c"
-        ],
-        "max_size": [
-            "100%",
-            180
-        ],
-        "anchor_from": "bottom_left",
-        "anchor_to": "bottom_left",
+        "size": [ 16, 16 ],
         "controls": [
+            {  "horizontal@hud.crosshair_pixel": {  "size": [ 9, 1 ]  }},
+            {  "vertical@hud.crosshair_pixel": {  "size": [ 1, 9 ]  }},
+            {  "dot@hud.crosshair_pixel": {  "size": [ 1, 1 ]  }}
+    ]},
+    "root_panel": {
+        "modifications": [
+            {   "array_name": "controls",
+                "operation": "insert_front",
+                "value": [
+                    { "chat_panel_bottom@hud.chat_panel_bottom": {}},
+                    { "crosshair_rewrite@hud.crosshair": {}},
+                    { "player_list@hud.player_list": {}}
+            ]}
+    ]},
+    // Add playerlist.
+    // Note - This weird tab padding has forced my hand.
+    //        lmao
+    "player_list": {
+        "type": "button",
+        "size": [ "100%", "100%" ],
+        "default_control": "default",
+        "hover_control": "hover",
+        "pressed_control": "pressed",
+        "button_mappings": [
             {
-                "messages_stack_panel": {
-                    "type": "stack_panel",
-                    "size": [
-                        "100%",
-                        "100%c"
-                    ],
-                    "anchor_from": "bottom_left",
-                    "anchor_to": "bottom_left",
-                    "factory": {
-                        "name": "chat_item_factory",
-                        "max_children_size": 10,
-                        "control_ids": {
-                            "chat_item": "chat_grid_item@hud.chat_grid_item"
-                        }
-                    }
-                }
+                "from_button_id": "button.scoreboard",
+                "to_button_id": "button.scoreboard",
+                "mapping_type": "global"
             }
-        ]
-    },
-    "anim_chat_bg_wait": {
-        "anim_type": "wait",
-        "duration": "$chat_item_lifetime",
-        "next": "@hud.anim_chat_bg_alpha"
-    },
-    "anim_chat_bg_alpha": {
-        "anim_type": "alpha",
-        "easing": "in_quart",
-        "destroy_at_end": "chat_grid_item",
-        "duration": 1,
-        "from": 0.5,
-        "to": 0
-    },
-    "anim_chat_txt_wait": {
-        "anim_type": "wait",
-        "duration": "$chat_item_lifetime",
-        "next": "@hud.anim_chat_txt_alpha"
-    },
-    "anim_chat_txt_alpha": {
-        "anim_type": "alpha",
-        "easing": "in_quart",
-        "duration": 1,
-        "from": 1,
-        "to": 0
-    },
-    "chat_grid_item": {
-        "type": "image",
-        "size": [
-            324,
-            "100%c"
         ],
-        "anchor_from": "bottom_left",
-        "anchor_to": "bottom_left",
-        "texture": "textures/chyves/color_base",
-        "color": [0.0, 0.0, 0.0],
-        "anims": [
-            "@hud.anim_chat_bg_wait"
-        ],
-        "alpha": 0.5,
         "controls": [
+            // Display whenever the said keymap are being pressed.
             {
-                "text_wrapper": {
-                    "type": "button",
-                    "size": [
-                        312,
-                        "100%c"
-                    ],
-                    "anchor_from": "bottom_left",
-                    "anchor_to": "bottom_left",
+                "pressed": {
+                    "type": "panel",
+                    "size": [ "100%", "100%" ],
                     "controls": [
                         {
-                            "text": {
-                                "type": "label",
-                                "text": "#text",
-                                "anchor_from": "bottom_left",
-                                "anchor_to": "bottom_left",
-                                "shadow": true,
-                                "localize": false,
-                                "size": [
-                                    312,
-                                    "default"
-                                ],
-                                "enable_profanity_filter": true,
-                                "anims": [
-                                    "@hud.anim_chat_txt_wait"
-                                ],
-                                "bindings": [
+                            "pressed@common.scrolling_panel": {
+                                "size": [ 124, "100%" ],
+                                "offset": [ 0, 20 ],
+                                "anchor_from": "top_middle",
+                                "anchor_to": "top_middle",
+                                "$scrolling_content": "hud.player_list_grid",
+                                "$show_background": false,
+                                "$always_handle_scrolling": true
+                            }                
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    // it's a player list grid.
+    "player_list_grid": {
+        "type": "grid",
+        "size": [ "100%c", "100%c" ],
+        "grid_item_template": "hud.player_list_grid_core",
+        "grid_dimension_binding": "#players_grid_dimension",
+        "collection_name": "players_collection",
+        "anchor_to": "top_middle",
+        "anchor_from": "top_middle",
+        "bindings": [
+            { "binding_name": "#players_grid_dimension" }
+    ]},
+    "player_list_grid_core": {
+        "type": "panel",
+        "size": [ 120, 9 ],
+        "controls": [
+            {
+                "background": {
+                    "type": "panel",
+                    "size": [ "100%", 10 ],
+                    "anchor_from": "top_middle",
+                    "anchor_to": "top_middle",
+                    "controls": [
+                        {
+                            "outline": {
+                                "type": "image",
+                                "texture": "textures/ui/background_with_border",
+                                "alpha": 0.5
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "player_profile_core": {
+                    "type": "stack_panel",
+                    "size": [ "100%", "100%" ],
+                    "orientation": "horizontal",
+                    "controls": [
+                        {
+                            "player_profile_panel": {
+                                "type": "panel",
+                                "size": [ 8, 8 ],
+                                "layer": 1,
+                                "controls": [
                                     {
-                                        "binding_name": "#text",
-                                        "binding_type": "collection",
-                                        "binding_collection_name": "chat_text_grid"
+                                        "player_profile": {
+                                            "type": "image",
+                                            "texture": "#texture",
+                                            "texture_file_system": "#texture_source",
+                                            "size": [ 8, 8 ],
+                                            "offset": [ 1, 1 ],
+                                            "bindings": [
+                                                {
+                                                    "binding_name": "#texture",
+                                                    "binding_type": "collection",
+                                                    "binding_collection_name": "players_collection"
+                                                },
+                                                {
+                                                    "binding_name": "#texture_source",
+                                                    "binding_name_override": "#texture_file_system",
+                                                    "binding_type": "collection",
+                                                    "binding_collection_name": "players_collection"
+                                                },
+                                                {
+                                                    "binding_name": "#gamerpic_visible",
+                                                    "binding_type": "collection",
+                                                    "binding_collection_name": "players_collection",
+                                                    "binding_name_override": "#visible"
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
-                                        "binding_type": "view",
-                                        "source_property_name": "#text",
-                                        "target_property_name": "#chat_text"
+                                        "player_profile_offline": {
+                                            "type": "image",
+                                            "texture": "textures/ui/lan_icon",
+                                            "size": [ 8, 8 ],
+                                            "offset": [ 1, 1 ],
+                                            "bindings": [
+                                                {
+                                                    "binding_name": "(not #gamerpic_visible)",
+                                                    "binding_type": "collection",
+                                                    "binding_collection_name": "players_collection",
+                                                    "binding_name_override": "#visible"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "padding_nametag": {
+                                "type": "panel",
+                                "size": [ 2, 2 ]
+                            }
+                        },
+                        {
+                            "player_name": {
+                                "type": "label",
+                                "text": "#gamertag",
+                                "size": [ "fill", "default" ],
+                                "text_alignment": "left",
+                                "shadow": true,
+                                "layer": 1,
+                                "bindings": [
+                                    {
+                                        "binding_name": "#gamertag",
+                                        "binding_type": "collection",
+                                        "binding_collection_name": "players_collection"
                                     }
                                 ]
                             }
@@ -370,6 +210,117 @@
             }
         ]
     },
+    // make sure touch does not have java message thing
+    // it makes chat more easy to read.
+    "chat_panel": {
+        "bindings": [
+            {   "binding_name": "#hud_visible_centered_touch",
+                "binding_type": "global",
+                "binding_name_override": "#visible"
+            }
+    ]},
+    "chat_panel_bottom": {
+        "type": "panel",
+        "anchor_from": "bottom_left",
+        "anchor_to": "bottom_left",
+        "size": [ 312, "100%c" ],
+        "max_size": [ 312, 200 ],
+        "offset": [ 2, -43 ],
+        "bindings": [
+        {   "binding_name": "#hud_visible_centered_touch",
+            "binding_type": "global"
+        },
+        {   "binding_type": "view",
+            "source_property_name": "(not #hud_visible_centered_touch)",
+            "target_property_name": "#visible"
+    }],
+    "controls": [
+        { "stack_panel": {
+              "type": "stack_panel",
+              "anchor_from": "bottom_left",
+              "anchor_to": "bottom_left",
+              "size": [ "100%", "100%c" ],
+              "factory": {
+                "name": "chat_item_factory",
+                "max_children_size": 15,
+                "control_ids": {
+                "chat_item": "chat_item@hud.chat_grid_item_bottom"
+          }}
+      }}
+  ]},
+  // ## Minimized the CGI bottom element.
+  "chat_grid_item_bottom": {
+    "type": "image",
+    "texture": "textures/ui/Black",
+    "alpha": 0.5,
+    "size": [ 312, "100%c" ],
+    "anims": [
+      "@hud.anim_chat_bg_wait_bottom"
+    ],
+    "bindings": [
+      { "binding_name": "(not #on_new_death_screen)",
+        "binding_name_override": "#visible"
+    }],
+    "controls": [
+      {
+        "text_wrapper": {
+            "type": "button",
+            "size": [
+                312,
+                "100%c"
+            ],
+            "anchor_from": "bottom_left",
+            "anchor_to": "bottom_left",
+            "layer": 5,
+            "controls": [
+                {
+                    "text": {
+                        "type": "label",
+                        "text": "#text",
+                        "anchor_from": "bottom_left",
+                        "anchor_to": "bottom_left",
+                        "shadow": true,
+                        "localize": false,
+                        "size": [
+                            312,
+                            "default"
+                        ],
+                        "enable_profanity_filter": true,
+                        "anims": [
+                            "@hud.anim_chat_txt_wait"
+                        ],
+                        "bindings": [
+                            {
+                                "binding_name": "#text",
+                                "binding_type": "collection",
+                                "binding_collection_name": "chat_text_grid"
+                            },
+                            {
+                                "binding_type": "view",
+                                "source_property_name": "#text",
+                                "target_property_name": "#chat_text"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+  ]},
+  // ## Bottom Anim Text.
+  "anim_chat_bg_alpha_bottom": {
+    "anim_type": "alpha",
+    "easing": "in_quart",
+    "destroy_at_end": "chat_text_thing",
+    "duration": 1,
+    "from": 0.5,
+    "to": 0
+  },
+  "anim_chat_bg_wait_bottom": {
+    "anim_type": "wait",
+    "duration": "$chat_item_lifetime",
+    "next": "@hud.anim_chat_bg_alpha_bottom"
+  },
   // ## Hotbar Tweaks for Touch only.
   //    This made "inventory" button invisible and leave only icon.
   //    Aswell make sure that the hotbar is always centered the same other platform has.

--- a/packs/RP/ui/pause_screen.json
+++ b/packs/RP/ui/pause_screen.json
@@ -5,16 +5,15 @@
     "size": [ "100%", "100%" ],
     "$achievements_ignored|default": false,
     "controls": [
-      { "menu@pause.pause_screen_menu": {} },
-      { "info_panel@pause.info_panel": {} }
-    ]
-  },
+      { "menu@pause.pause_screen_menu": {}},
+      { "info_panel@pause.info_panel": {}}
+  ]},
   "pause_screen_menu": {
     "type": "panel",
     "size": [ "fill", "100%" ],
     "controls": [
-      { "the_rest_panel@pause.the_rest_panel_own": {} },
-      { "the_icon_panel@pause.the_icon_panel": {} }
+      { "the_rest_panel@pause.the_rest_panel_own": {}},
+      { "the_icon_panel@pause.the_icon_panel": {}}
     ]
   },
   "the_icon_panel/stacked_column/side_padding": {
@@ -38,6 +37,14 @@
     "controls": [
       { "pause_menu@pause.menu_background_own": {}
   }]},
+  "info_panel":{
+    "bindings": [
+      { "binding_type": "view",
+        "source_control_name": "pause_more_player",
+        "source_property_name": "#toggle_state",
+        "target_property_name": "#visible"
+    }]
+  },
   "pause_button_template@common_buttons.light_text_button": {
     "$button_type_panel": "pause.new_ui_binding_button_label_classic",
     "$default_button_texture": "textures/ui/vanilla_default",
@@ -52,17 +59,73 @@
     "$button_image_size": [ "100%", "100%" ],
     "$border_visible": false,
     "$border_alpha": 0,
+    "$button_pressed_offset": [ 0, 0 ],
     "focus_identifier": "$pressed_button_name",
     "focus_change_right": "$focus_override_right",
     "focus_change_left": "$pressed_button_name"
+  },
+  "dark_template_toggle@common_toggles.light_template_toggle": {
+    "$button_type_panel": "pause.new_ui_binding_button_label_classic",
+    "$button_text_binding_type|default": "none",
+    "$button_text_grid_collection_name|default": "",
+    "$button_binding_condition|default": "none",
+
+    "$default_texture": "textures/ui/vanilla_default",
+    "$hover_texture": "textures/ui/vanilla_default",
+    "$pressed_texture": "textures/ui/vanilla_pressed",
+    "$pressed_no_hover_texture": "textures/ui/vanilla_pressed",
+    "$border_alpha": 0,
+    "$button_image_size": [ "100%", "100%" ],
+    "$button_offset": [ 0, 0 ],
+    
+    "$default_text_color": "$light_button_hover_text_color",
+    "$hover_text_color": [ 1, 0.9607, 0.8117 ],
+    "$default_checked_text_color": "$light_button_hover_text_color",
+    "$hover_checked_text_color": [ 1, 0.9607, 0.8117 ],
+    "$default_border_visible": false,
+    "$hover_border_visible": false
   },
   "new_ui_binding_button_label_classic@common_buttons.new_ui_binding_button_label": {
     "shadow": true
   },
   "dressing_room_button_own@pause.pause_button_template": {
+    "size": [ 98, 20 ],
     "$pressed_button_name": "button.to_profile_or_skins_screen",
     "$button_text": "profileScreen.header",
     "$focus_id": "profile_button"
+  },
+  "more_player_toggle@common_toggles.light_ui_toggle": {
+    "$template_toggle": "pause.dark_template_toggle",
+    "size": [ 98, 20 ],
+    "$button_text": "Player(s)",
+    "$toggle_name": "pause_more_player",
+    "$toggle_view_binding_name": "pause_more_player",
+    "$button_mappings": [
+      { "from_button_id": "button.controller_start",
+        "to_button_id": "button.controller_start",
+        "mapping_type": "global"
+      },
+      { "from_button_id": "button.scoreboard",
+        "to_button_id": "button.scoreboard",
+        "mapping_type": "global"
+      },
+      { "from_button_id": "button.menu_select",
+        "to_button_id": "button.menu_select",
+        "mapping_type": "pressed"
+      },
+      { "from_button_id": "button.menu_ok",
+        "to_button_id": "button.menu_ok",
+        "mapping_type": "focused"
+    }]
+  },
+  "return_to_game_button": {
+    "$button_text": "Back to game"
+  },
+  "settings_button": {
+    "$button_text": "Options..."
+  },
+  "quit_button": {
+    "$button_text": "Save and quit to title"
   },
   "pause_menu_label": {
     "type": "panel",
@@ -82,7 +145,7 @@
       { "paused_label_with": {
           "type": "label",
           "text_alignment": "center",
-          "text": "Game menu (Paused)",
+          "text": "Game menu §7§o(Paused)",
           "shadow": true,
           "bindings": [
             { "binding_name": "#pause_annoucement_visible",
@@ -91,6 +154,9 @@
           }]
       }}
   ]},
+  "vertical_padding": {
+    "size": [ 0, 4 ]
+  },
   "menu_background_own": {
     "type": "panel",
     "size": [ "50%", "100%c + 8px" ],
@@ -108,8 +174,18 @@
             { "pause_menu_label@pause_menu_label": {}},
             { "pause_menu_label_padding": { "type": "panel", "size": [ "100%", 30 ]}},
             { "return_to_game_button@pause.return_to_game_button": {} },
-            { "return@pause.vertical_padding": {} },
-            { "realms_stories_button_panel@pause.realms_stories_button_panel": {} },
+            { "return_to_game_button_padding@pause.vertical_padding": {}},
+            { "sub_button_00": {
+                "type": "stack_panel",
+                "orientation": "horizontal",
+                "size": [ 200, 20 ],
+                "controls": [
+                  { "dressing_room_button@pause.dressing_room_button_own": {}},
+                  { "padding": { "type": "panel", "size": [ 4, 4 ]}},
+                  { "more_player_toggle@pause.more_player_toggle": {}}
+            ]}},
+            { "large_padding": { "type": "panel", "size": [ "100%", 30 ]}},
+            { "realms_stories_button_panel@pause.realms_stories_button_panel": {}},
             { "realms_stories@pause.vertical_padding": {
                 "bindings": [
                   { "binding_name": "#is_realm_level",
@@ -117,11 +193,9 @@
                     "binding_type": "global"
                 }]
             }},
-            { "settings_button@pause.settings_button": {} },
+            { "settings_button@pause.settings_button": {}},
             { "settings@pause.vertical_padding": {}},
-            { "dressing_room_button@pause.dressing_room_button_own": {}},
-            { "dressing_room_padding": { "type": "panel", "size": [ "100%", 15 ]}},
-            { "quit_button@pause.quit_button": {} }
+            { "quit_button@pause.quit_button": {}}
           ]
         }
       }


### PR DESCRIPTION
- Added Playerlist on Hud screen (Tab button)
   - This is only exclusive to Keyboard/Mouse players.
   - Does not exist in beta-1.7.3, but we're adding it anyways.
   - Classic styled, not modern.
- Improved Chat Related
   - Fixed an issue with mobile largest UI scale can cause the type box burried. ( Chat Screen )
   - Replaced a chat message with better one with more fixes in all together, No black lines, No message random paddings, Only Controller and Keyboard/Mouse exclusive. ( Mobile players will have their vanilla chat message UI back due to being unreadable on controls. )
- Improved Hud Screen with alot of optimizations.
- Improved Pause Screen
   - The menu is now 99% accurate to beta-1.7.3, with dressing room and Player(s) button existance.
   - Few buttons text has changed to match the beta-1.7.3
   - Playerlist are hidden by default.
   - Player(s) button will open playerlist, which can also be accessed by - Tab button and Start button on any controller.