### PR TITLE
Big Inventory screen update.

### DIFF
--- a/packs/RP/ui/inventory_screen.json
+++ b/packs/RP/ui/inventory_screen.json
@@ -1,200 +1,618 @@
 {
-    // ## Remove toolbar.
-    "toolbar_panel": {
-        "ignored": true
-    },
-    // ## Remove recipe toggle
-    "recipe_inventory_screen_content/content_stack_panel/recipe_book": {
-        "ignored": true
-    },
-    // ## Remove that center background.
-    "recipe_inventory_screen_content/content_stack_panel/center_fold": {
-        "ignored": true
-    },
-    // ## Remove Shield slot.
-    // WARN: Controller's "Y" button or Ctrl + L-click may still
-    // insert the stuff into shield slot.
-    // There's no fix :(
-    "player_armor_panel/offhand_grid": {
-        "ignored": true
-    },
-    "close_button_default": {
-        "type": "label",
-        "text": "X"
-    },
-    "close_button_pressed": {
-        "type": "label",
-        "text": "§eX"
-    },
-    "close_button@common.button": {
-        "$pressed_button_name": "button.menu_exit",
-        "size": [
-            27,
-            27
-        ],
-        "focus_enabled": false,
-        "controls": [
+  // ## Remove toolbar.
+  "toolbar_panel": {
+    "ignored": false
+  },
+  "creative_label": {
+    "text_alignment": "left"
+  },
+  "layout_toggle_betafied@common_tabs.tab_right": {
+    "size": [ 29, 25 ],
+    "$tab_content": "crafting.empty_tab_panel",
+    "$toggle_name": "layout_toggle",
+    //"$template_toggle": "crafting.layout_template_toggle",
+    "$allow_controller_back_button_mapping": "$is_ps4"
+  },
+
+  "creative_layout_toggle@crafting.layout_toggle_betafied": {
+    "$tab_icon": "crafting.creative_icon",
+    "$toggle_group_forced_index": "$creative_layout_index",
+    "$toggle_binding_type": "global",
+    "$toggle_state_binding_name": "#is_creative_layout",
+    "$focus_id": "creative_layout_toggle",
+    "$toggle_tts_header": "accessibility.button.creative.layout"
+  },
+  "recipe_book_layout_toggle@crafting.layout_toggle_betafied": {
+    "$is_bottom_most_tab": true,
+    "$tab_icon": "crafting.recipe_book_icon",
+    "$toggle_group_forced_index": "$recipe_book_layout_index",
+    "$toggle_binding_type": "global",
+    "$toggle_state_binding_name": "#is_recipe_book_layout",
+    "$focus_id": "recipe_book_layout_toggle",
+    "$toggle_tts_header": "accessibility.button.recipebook.layout"
+  },
+  "survival_layout_toggle@crafting.layout_toggle_betafied": {
+    "$is_bottom_most_tab": true,
+    "$tab_icon": "crafting.inventory_icon",
+    "$toggle_group_forced_index": "$survival_layout_index",
+    "$toggle_binding_type": "global",
+    "$toggle_state_binding_name": "#is_survival_layout",
+    "$toggle_tts_header": "accessibility.button.survival.layout"
+  },
+  "toolbar_panel@crafting.crafting_root_panel": {
+    "size": [ "100%c", "100%" ],
+    "anchor_from": "bottom_right",
+    "anchor_to": "bottom_right",
+    "offset": [ 25, 0 ],
+    "controls": [
+      {
+        "toolbar_stack_panel": {
+          "type": "stack_panel",
+          "orientation": "vertical",
+          "ttsSectionContainer": true,
+          "size": [ "100%cm", "100%" ],
+          "controls": [
             {
-                "default@close_button_default": {}
+              "empty_fill": {
+                "type": "panel",
+                "size": [ "100%c", "fill" ]
+              }
             },
             {
-                "hover@close_button_pressed": {}
-            },
-            {
-                "pressed@close_button_pressed": {}
-            }
-        ]
-    },
-    "close_button_element": {
-        "type": "image",
-        "texture": "textures/ui/hud_tip_text_background",
-        "size": [
-            27,
-            27
-        ],
-        "anchor_from": "top_right",
-        "anchor_to": "top_right",
-        "offset": [
-            -8,
-            8
-        ],
-        "alpha": 0.7,
-        "controls": [
-            {
-                "close_button@close_button": {
-                    "layer": 2
-                }
-            }
-        ]
-    },
-    "crafting_panel_2x2": {
-        "type": "panel",
-        "size": [
-            88,
-            83
-        ],
-        "anchor_from": "top_middle",
-        "anchor_to": "top_left",
-        "offset": [
-            -6,
-            9
-        ],
-        "controls": [
-            {
-                "crafting_arrow@crafting_arrow": {
-                    "offset": [
-                        46,
-                        29
-                    ],
-                    "bindings": [
-                        {
-                            "binding_type": "view",
-                            "source_control_name": "crafting_panel",
-                            "resolve_sibling_scope": true,
-                            "source_property_name": "(not #needs_crafting_table)",
-                            "target_property_name": "#visible"
-                        }
-                    ]
-                }
-            },
-            {
-                "crafting_table@crafting.item_renderer": {
-                    "offset": [
-                        10,
-                        -5
-                    ],
-                    "property_bag": {
-                        "#item_id_aux": 3801088
-                    },
-                    "bindings": [
-                        {
-                            "binding_type": "view",
-                            "source_control_name": "crafting_panel",
-                            "resolve_sibling_scope": true,
-                            "source_property_name": "(#needs_crafting_table)",
-                            "target_property_name": "#visible"
-                        }
-                    ]
-                }
-            },
-            {
-                "crafting_grid_2x2@crafting.crafting_grid_2x2_with_label": {
-                    "offset": [
-                        8,
-                        7
-                    ]
-                }
-            },
-            {
-                "survival_crafting_output_grid@crafting.output_grid_2x2": {
-                    "offset": [
-                        64,
-                        26
-                    ]
-                }
-            }
-        ],
-        "bindings": [
-            {
-                "binding_name": "#needs_crafting_table",
-                "binding_condition": "visible"
-            }
-        ]
-    },
-    // ## Adds some padding because apparently they're not dynamically centered.
-    //    Thanks mojang, very cool!
-    "recipe_inventory_screen_content/content_stack_panel": {
-        "modifications": [
-            {
-                "array_name": "controls",
-                "operation": "insert_front",
-                "value": [
-                    {
-                        "recipe_book@crafting.recipe_book": {
-                            "size": [
-                                "fill",
-                                "100%"
-                            ],
-                            "bindings": [
-                                {
-                                    "binding_type": "global",
-                                    "binding_name": "(#is_creative_layout)",
-                                    "binding_name_override": "#visible"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "survival_padding_no_recipe": {
-                            "type": "panel",
-                            "size": [
-                                75,
-                                "100%"
-                            ],
-                            "bindings": [
-                                {
-                                    "binding_type": "global",
-                                    "binding_name": "(not #is_survival_layout)",
-                                    "binding_name_override": "#visible"
-                                }
-                            ]
-                        }
+              "left_trigger_anchor": {
+                "type": "panel",
+                "ignored": true,
+                "size": [ 0, "100%" ],
+                "bindings": [
+                  {
+                    "binding_name": "#gamepad_helper_visible",
+                    "binding_name_override": "#visible"
+                  }
+                ],
+                "controls": [
+                  {
+                    "gamepad_helper_left_trigger@common.gamepad_helper_left_trigger": {
+                      "offset": [ 3, -2 ],
+                      "anchor_from": "left_middle",
+                      "anchor_to": "right_middle"
                     }
+                  }
                 ]
-            }
-        ]
-    },
-    "recipe_inventory_screen_content": {
-        "modifications": [
+              }
+            },
             {
-                "array_name": "controls",
-                "operation": "insert_front",
-                "value": [
-                    {
-                        "close_button_element@crafting.close_button_element": {}
+              "creative_layout_toggle_panel": {
+                "type": "panel",
+                "size": [ "100%c", 25 ],
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "#creative_layout_button_visible",
+                    "binding_name_override": "#visible"
+                  }
+                ],
+                "controls": [
+                  {
+                    "creative_layout_toggle@crafting.creative_layout_toggle": {
+                      "$focus_override_left": "search_tab"
                     }
+                  }
                 ]
+              }
+            },
+            {
+              "padding_1": {
+                "type": "panel",
+                "size": [ 2, 0 ],
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "#creative_layout_button_visible",
+                    "binding_name_override": "#visible"
+                  }
+                ]
+              }
+            },
+            {
+              "recipe_book_layout_toggle_panel_creative": {
+                "type": "panel",
+                "size": [ "100%c", 25 ],
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "(not #is_recipe_book_layout)",
+                    "binding_name_override": "#visible"
+                  }
+                ],
+                "controls": [
+                  { "recipe_book_layout_toggle@crafting.recipe_book_layout_toggle": {
+                      "bindings": [
+                        {
+                          "binding_type": "global",
+                          "binding_name": "#is_creative_mode",
+                          "binding_name_override": "#visible"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "padding_2": {
+                "type": "panel",
+                "size": [ 1, 0 ]
+              }
+            },
+            {
+              "survival_layout_toggle_panel": {
+                "type": "panel",
+                "size": [ "100%c", 25 ],
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "#is_recipe_book_layout",
+                    "binding_name_override": "#visible"
+                  }
+                ],
+                "controls": [
+                  { "survival_layout_toggle@crafting.survival_layout_toggle": {
+                      "bindings": [
+                        
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "right_trigger_anchor": {
+                "type": "panel",
+                "size": [ 0, "100%" ],
+                "bindings": [
+                  {
+                    "binding_name": "#gamepad_helper_visible",
+                    "binding_name_override": "#visible"
+                  }
+                ],
+                "controls": [
+                  {
+                    "gamepad_helper_right_trigger@common.gamepad_helper_right_trigger": {
+                      "offset": [ -2, -2 ],
+                      "anchor_from": "right_middle",
+                      "anchor_to": "left_middle"
+                    }
+                  }
+                ]
+              }
             }
-        ]
-    }
+          ]
+        }
+      }
+    ]
+  },
+  "recipe_book@common.root_panel": {
+    "layer": 1,
+    "controls": [
+      {
+        "gamepad_helper_bumpers@crafting.gamepad_helper_bumpers": {
+          "size": [ 176, 16 ],
+          "offset": [ 0, -5 ],
+          "anchor_from": "top_left",
+          "anchor_to": "bottom_left",
+          "bindings": [
+            {
+              "binding_type": "global",
+              "binding_name": "#is_creative_mode",
+              "binding_name_override": "#visible"
+            }
+          ]
+        }
+      },
+      {
+        "tab_navigation_panel@crafting.tab_navigation_panel_layout": {
+          "layer": 5,
+          "size": [ 176, 23 ],
+          "anchor_from": "top_left",
+          "anchor_to": "bottom_left",
+
+          "$is_search_right_most_tab": "#is_recipe_book_layout",
+          "bindings": [
+            {
+              "binding_type": "global",
+              "binding_name": "#is_recipe_book_layout"
+            },
+            {
+              "binding_type": "global",
+              "binding_name": "#is_creative_mode",
+              "binding_name_override": "#visible"
+            }
+          ]
+        }
+      },
+      {
+        "bg@common.common_panel": {
+          "layer": 8,
+          "$show_close_button": false
+        }
+      },
+      {
+        "tab_content_panel@crafting.tab_content": {
+          "size": [ "100%", "100%" ],
+          "layer": 8,
+          "$scrolling_pane_control": "crafting.recipe_book_scroll_panel",
+          "bindings": [
+            {
+              "binding_type": "global",
+              "binding_name": "#is_creative_mode",
+              "binding_name_override": "#visible"
+            }
+          ]
+        }
+      },
+      {
+        "extra_panel_cuz_screw_you_minecraft": {
+          "type": "panel",
+          "bindings": [
+            {
+              "binding_type": "global",
+              "binding_name": "#is_creative_mode",
+              "binding_name_override": "#visible"
+            }
+          ],
+          "controls": [
+            {
+              "creative_hotbar_panel@crafting.creative_hotbar_panel": {
+                "layer": 3,
+                "offset": [ 0, -6 ],
+                "anchor_from": "bottom_middle",
+                "anchor_to": "top_middle",
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "#is_recipe_book_layout",
+                    "binding_name_override": "#visible"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      { "main_label": {
+          "type": "label",
+          "offset": [ 2, 0 ],
+          "size": [ "100% - 8px", "default" ],
+          "layer": 80,
+          "shadow": true,
+          "text": "Recipe is not available on survival...",
+          "bindings": [
+            { "binding_type": "global",
+              "binding_name": "(not #is_creative_mode)",
+              "binding_name_override": "#visible"
+          }],
+          "controls": [
+            { "background": {
+                "type": "image",
+                "size": [ "100% + 10px", "100% + 12px" ],
+                "layer": -1,
+                "alpha": 0.7,
+                "offset": [ -2, 0 ],
+                "texture": "textures/ui/hud_tip_text_background"
+            }}
+      ]}}
+    ]
+  },
+  "creative_hotbar_panel/creative_hotbar_background": {
+    "size": [ "100%c + 14px", "100%c + 10px" ]
+  },
+  "creative_hotbar_panel/creative_hotbar_background/hotbar_grid": {
+    "offset": [ 0, -6 ]
+  },
+  "recipe_inventory_screen_content_betafied": {
+    "type": "panel",
+    "controls": [
+      {
+        "content_stack_panel": {
+          "type": "stack_panel",
+          "size": [ 326, 166 ],
+          "orientation": "horizontal",
+
+          "controls": [
+            // ## FIX:
+            //    This thing does not go well with both layout bindings in the same operator.
+            //    ** THIS WILL CRASH THE GAME **
+            {
+              "survival_padding": {
+                "type": "panel",
+                "size": [ 75, "100%" ],
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "(not #is_creative_layout)",
+                    "binding_name_override": "#visible"
+                  }
+                ]
+              }
+            },
+            {
+              "recipe_book@crafting.recipe_book": {
+                "size": [ 176, 166 ],
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "(not #is_survival_layout)",
+                    "binding_name_override": "#visible"
+                  }
+                ]
+              }
+            },
+            {
+              "player_inventory@crafting.player_inventory": {
+                "bindings": [
+                  {
+                    "binding_type": "global",
+                    "binding_name": "(not #is_recipe_book_layout)",
+                    "binding_name_override": "#visible"
+                  }
+                ]
+              }
+            },
+            {
+              "toolbar_anchor": {
+                "type": "panel",
+                "size": [ 0, "100%" ],
+                "controls": [
+                  {
+                    "toolbar_panel@crafting.toolbar_panel": {
+                      "anchor_from": "bottom_right",
+                      "anchor_to": "bottom_right"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+
+      { "inventory_take_progress_icon_button@common.inventory_take_progress_icon_button": {} },
+      { "inventory_selected_icon_button@common.inventory_selected_icon_button": {} },
+      { "hold_icon@common.inventory_take_progress_icon_button": {} },
+      {
+        "controller_gamepad_helpers_stack_panel": {
+          "type": "stack_panel",
+          "anchor_from": "bottom_middle",
+          "anchor_to": "bottom_middle",
+          "controls": [
+            { "container_gamepad_helpers_second_row@crafting.container_gamepad_helpers_second_row": {} },
+            {
+              "container_gamepad_helpers@common.container_gamepad_helpers": {
+                "$helper_x_control": "crafting.inventory_x_gamepad_helper",
+                "$helper_y_control": "crafting.inventory_y_gamepad_helper",
+                "$helper_a_control": "crafting.inventory_a_gamepad_helper"
+              }
+            }
+          ],
+          "bindings": [
+            {
+              "binding_name": "#gamepad_helper_visible",
+              "binding_name_override": "#visible"
+            }
+          ]
+        }
+      },
+      { "selected_item_details_factory@common.selected_item_details_factory": {} },
+      { "item_lock_notification_factory@common.item_lock_notification_factory": {} }
+    ]
+  },
+  "inventory_container_slot_button@common.container_slot_button_prototype": {
+    "$button_take_half_place_one|default": "button.container_take_half_place_one",
+    "$button_auto_place|default": "button.container_auto_place",
+    "$button_take_all_place_all|default": "button.container_take_all_place_all",
+    "$coalesce_button|default": "button.coalesce_stack",
+    "button_mappings": [
+      {
+        "from_button_id": "button.menu_cancel",
+        "to_button_id": "button.try_menu_exit",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_select",
+        "to_button_id": "$button_take_all_place_all",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_ok",
+        "to_button_id": "$button_take_all_place_all",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.controller_back",
+        "to_button_id": "$button_take_all_place_all",
+        "mapping_type": "pressed",
+        "ignored": "(not $is_ps4)"
+      },
+      {
+        "from_button_id": "button.menu_secondary_select",
+        "to_button_id": "$button_take_half_place_one",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.controller_select",
+        "to_button_id": "$button_take_half_place_one",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_inventory_drop",
+        "to_button_id": "button.drop_one",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_inventory_drop_all",
+        "to_button_id": "button.drop_all",
+        "mapping_type": "pressed"
+      },
+      {
+        "to_button_id": "button.shape_drawing",
+        "mapping_type": "pressed"
+      },
+      {
+        "to_button_id": "button.container_slot_hovered",
+        "mapping_type": "pressed"
+      }
+    ]
+  },
+  "no_coalesce_container_slot_button@crafting.inventory_container_slot_button": {
+    "button_mappings": [
+      {
+        "from_button_id": "button.menu_cancel",
+        "to_button_id": "button.try_menu_exit",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_select",
+        "to_button_id": "$button_take_all_place_all",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_ok",
+        "to_button_id": "$button_take_all_place_all",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.controller_back",
+        "to_button_id": "$button_take_all_place_all",
+        "mapping_type": "pressed",
+        "ignored": "(not $is_ps4)"
+      },
+      {
+        "from_button_id": "button.menu_secondary_select",
+        "to_button_id": "$button_take_half_place_one",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.controller_select",
+        "to_button_id": "$button_take_half_place_one",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_inventory_drop",
+        "to_button_id": "button.drop_one",
+        "mapping_type": "pressed"
+      },
+      {
+        "from_button_id": "button.menu_inventory_drop_all",
+        "to_button_id": "button.drop_all",
+        "mapping_type": "pressed"
+      },
+      {
+        "to_button_id": "button.container_slot_hovered",
+        "mapping_type": "pressed"
+      }
+    ]
+  },
+  "player_armor_panel/offhand_grid": {
+    "ignored": true
+  },
+  "close_button_default": {
+    "type": "label",
+    "text": "X"
+  },
+  "close_button_pressed": {
+    "type": "label",
+    "text": "§eX"
+  },
+  "close_button@common.button": {
+    "$pressed_button_name": "button.menu_exit",
+    "size": [ 27, 27 ],
+    "focus_enabled": false,
+    "controls": [
+      { "default@close_button_default": {} },
+      { "hover@close_button_pressed": {} },
+      { "pressed@close_button_pressed": {} }
+  ]},
+  "close_button_element": {
+    "type": "image",
+    "texture": "textures/ui/hud_tip_text_background",
+    "size": [ 27, 27 ],
+    "anchor_from": "top_right",
+    "anchor_to": "top_right",
+    "offset": [ -8, 8 ],
+    "alpha": 0.7,
+    "controls": [
+      { "close_button@close_button": {
+          "layer": 2
+      }}
+  ]},
+  "crafting_panel_2x2": {
+    "type": "panel",
+    "size": [ 88, 83 ],
+    "anchor_from": "top_middle",
+    "anchor_to": "top_left",
+    "offset": [ -6, 9 ],
+    "controls": [
+      {
+        "crafting_arrow@crafting_arrow": {
+          "offset": [ 46, 29 ],
+          "bindings": [
+            {
+              "binding_type": "view",
+              "source_control_name": "crafting_panel",
+              "resolve_sibling_scope": true,
+              "source_property_name": "(not #needs_crafting_table)",
+              "target_property_name": "#visible"
+            }
+          ]
+        }
+      },
+      {
+        "crafting_table@crafting.item_renderer": {
+          "offset": [ 10, -5 ],
+          "property_bag": {
+            "#item_id_aux": 3801088
+          },
+          "bindings": [
+            {
+              "binding_type": "view",
+              "source_control_name": "crafting_panel",
+              "resolve_sibling_scope": true,
+              "source_property_name": "(#needs_crafting_table)",
+              "target_property_name": "#visible"
+            }
+          ]
+        }
+      },
+      {
+        "crafting_grid_2x2@crafting.crafting_grid_2x2_with_label": {
+          "offset": [ 8, 7 ]
+        }
+      },
+      {
+        "survival_crafting_output_grid@crafting.output_grid_2x2": {
+          "offset": [ 64, 26 ]
+        }
+      }
+    ],
+    "bindings": [
+      {
+        "binding_name": "#needs_crafting_table",
+        "binding_condition": "visible"
+      }
+    ]
+  },
+  "crafting_screen@crafting.inventory_screen_base": {
+    "$screen_content": "crafting.recipe_inventory_screen_content_betafied"
+  },
+  "inventory_screen@crafting.inventory_screen_base": {
+    "$screen_content": "crafting.recipe_inventory_screen_content_betafied"
+  },
+  "recipe_inventory_screen_contents": {
+    "modifications": [
+      { "array_name": "controls",
+        "operation": "insert_front",
+        "value": [
+          { "close_button_element@crafting.close_button_element": {}}
+      ]}
+  ]}
 }


### PR DESCRIPTION
This might be my last pull request but here we are, im not leaving this unfinished.

- Added Creative menu!
  - Nearly a replica that cen0b showed me.
  - Creative tab are toggle.
  - Creative text and few among things has changed.
- Added failsafe for recipe menu - when you have recipe menu toggled via other addons or stuff, it'll say that its not available and allows you to go back inventory screen.
- Removed Shift+Click or double-tap to quick equip or quick placement for parity.
   - This also means that you no longer put any stuff to offhand.
- Big Creative tab still exists but now instead it'll show both inventory and creative menu.